### PR TITLE
Taking the integral part of the frame to be assigned to the item. If …

### DIFF
--- a/KTCenterFlowLayout.m
+++ b/KTCenterFlowLayout.m
@@ -89,7 +89,7 @@
       else
         itemFrame.origin.x = CGRectGetMaxX(previousFrame) + interitemSpacing;
 
-      itemAttributes.frame = itemFrame;
+      itemAttributes.frame = CGRectIntegral(itemFrame);
       previousFrame = itemFrame;
     }
   }];


### PR DESCRIPTION
If the frame assigned to the item in the line 92
`itemAttributes.frame = itemFrame;`
has decimals, an ugly effect is produced to the circular border if exists:

Without CGRectIntegral:
![without_cgrectintegral](https://cloud.githubusercontent.com/assets/1689743/13790195/85ccac10-eae7-11e5-9bb7-fcd8226e5979.jpg)

With CGRectIntegral
![with_cgrectintegral](https://cloud.githubusercontent.com/assets/1689743/13789963/960233f8-eae6-11e5-8909-7f4ef7018cf1.jpg)
