### PR TITLE
Implement -layoutAttributesForItemAtIndexPath:

### DIFF
--- a/KTCenterFlowLayout.m
+++ b/KTCenterFlowLayout.m
@@ -97,4 +97,21 @@
   return superAttributes;
 }
 
+- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
+    UICollectionViewLayoutAttributes *superAttributes = [super layoutAttributesForItemAtIndexPath:indexPath];
+    
+    // Rect that encompasses all items on indexPath's line.
+    CGRect lineRect = CGRectMake(0.0, CGRectGetMinY(superAttributes.frame), CGRectGetWidth(self.collectionView.frame), CGRectGetHeight(superAttributes.frame));
+    
+    NSArray *lineAttributes = [self layoutAttributesForElementsInRect:lineRect];
+    
+    for (UICollectionViewLayoutAttributes *itemAttributes in lineAttributes) {
+        if (itemAttributes.indexPath == indexPath) {
+            return itemAttributes;
+        }
+    }
+    
+    return nil;
+}
+
 @end


### PR DESCRIPTION
Implementing `-layoutAttributesForItemAtIndexPath:` is needed for when self-sizing cells is being used, since in that case collection view asks for layout attributes individually for each index path.

The most efficient way for doing this would be caching all the positions and invalidate them when the invalidation context has `invalidateEverything`, `invalidateFlowLayoutDelegateMetrics` or `invalidateFlowLayoutAttributes` to `true`, but this quick fix still does the job.

Thank you for your time and layout.
