### PR TITLE
layoutattributesforelementsinrect wrong rect

### DIFF
--- a/KTCenterFlowLayout.m
+++ b/KTCenterFlowLayout.m
@@ -35,7 +35,7 @@
 
             UICollectionViewLayoutAttributes *attrs = [self layoutAttributesForItemAtIndexPath:indexPath];
             
-            if (attrs && CGRectIntersectsRect(attrs.frame, rect))
+            if (attrs)
             {
                 [updatedAttributes addObject:attrs];
             }
@@ -43,7 +43,7 @@
             UICollectionViewLayoutAttributes *headerAttrs =  [super layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
                                                                                                    atIndexPath:indexPath];
 
-            if (headerAttrs && CGRectIntersectsRect(headerAttrs.frame, rect))
+            if (headerAttrs)
             {
                 [updatedAttributes addObject:headerAttrs];
             }
@@ -51,7 +51,7 @@
             UICollectionViewLayoutAttributes *footerAttrs =  [super layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionFooter
                                                                                                    atIndexPath:indexPath];
 
-            if (footerAttrs && CGRectIntersectsRect(footerAttrs.frame, rect))
+            if (footerAttrs)
             {
                 [updatedAttributes addObject:footerAttrs];
             }


### PR DESCRIPTION
Hello, in the process of using, encountered some cell will not show the problem.Ultimately, the problem is that the rect of the `layoutAttributesForElementsInRect` is not the actual Rect, or the final Rect.So I made these changes, and I don't know if it would happen, but it fixes my mistake.

>Apple's answer to this on devforums was to adhere to their docs and return any elements that intersect the rect parameter without regards to whether rect makes sense or not. 
[Reference link](https://stackoverflow.com/questions/24396095/uicollectionview-custom-layout-issue-with-layoutattributesforelementsinrectrect)
